### PR TITLE
MSBuild bug when path contains blanks

### DIFF
--- a/build/bower.js.targets
+++ b/build/bower.js.targets
@@ -9,12 +9,12 @@
 	</PropertyGroup>
 	<Target Name="InstallBower">
 		<Message Text="Installing Bower..."/>
-		<Exec Condition=" !Exists('$(NodeModulesBower)')" Command="$(MSBuildThisFileDirectory)..\tools\npm.cmd install bower --save-dev" WorkingDirectory="$(SolutionDir)" />
+		<Exec Condition=" !Exists('$(NodeModulesBower)')" Command="&quot;$(MSBuildThisFileDirectory)..\tools\npm.cmd&quot; install bower --save-dev" WorkingDirectory="$(SolutionDir)" />
 		<Message Text="Bower installed!"/>
 	</Target>
 	<Target Name="RestoreBowerPkgs" DependsOnTargets="InstallBower">
 		<Message Text="Restoring Bower packages..." Condition="'$(DONT_INSTALL_BOWER)' == ''"/>
-		<Exec Command="$(MSBuildThisFileDirectory)..\tools\bower install" Condition="'$(DONT_INSTALL_BOWER)' == ''" />
+		<Exec Command="&quot;$(MSBuildThisFileDirectory)..\tools\bower&quot; install" Condition="'$(DONT_INSTALL_BOWER)' == ''" />
 		<Message Text="Bower not installed, environment variable 'DONT_INSTALL_BOWER' set." Condition="'$(DONT_INSTALL_BOWER)' != ''" />
 		<Message Text="Bower packages restored!" Condition="'$(DONT_INSTALL_BOWER)' == ''"/>
     </Target>

--- a/tools/bower.cmd
+++ b/tools/bower.cmd
@@ -1,3 +1,3 @@
 @echo off
-for /f "delims=" %%A in ('dir %~dp0..\..\node.js.* /b') do set "nodePath=%%A"
+for /f "delims=" %%A in ('dir "%~dp0..\..\node.js.*" /b') do set "nodePath=%%A"
 "%~dp0..\..\%nodePath%\node.exe" "%~dp0..\..\..\node_modules\bower\bin\bower" %*

--- a/tools/npm.cmd
+++ b/tools/npm.cmd
@@ -1,3 +1,3 @@
 @echo off
-for /f "delims=" %%A in ('dir %~dp0..\..\npm* /b') do set "npmPath=%%A"
+for /f "delims=" %%A in ('dir "%~dp0..\..\npm*" /b') do set "npmPath=%%A"
 "%~dp0..\..\%npmPath%\tools\npm.cmd" %*


### PR DESCRIPTION
some windows paths include blanks, therefore there is a need for double quotes to work without error
example: C:\User\Visual Studio Workspace\bower-nuget\ should be "C:\User\Visual Studio Workspace\bower-nuget\" to work in terminal without errors

![bower-nuget](https://f.cloud.github.com/assets/6577779/2148964/9b2a128a-93ed-11e3-917b-a3dab273b275.PNG)
This error occours while building our project. (Notice blanks in path "Visual Studio Workspace").
