### PR TITLE
Added interactive=false for unattended restore

### DIFF
--- a/build/bower.js.targets
+++ b/build/bower.js.targets
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 	<Target Name="InstallBower">
 		<Message Text="Installing Bower..."/>
-		<Exec Condition=" !Exists('$(NodeModulesBower)')" Command="&quot;$(MSBuildThisFileDirectory)..\tools\npm.cmd&quot; install bower --save-dev" WorkingDirectory="$(SolutionDir)" />
+		<Exec Condition=" !Exists('$(NodeModulesBower)')" Command="&quot;$(MSBuildThisFileDirectory)..\tools\npm.cmd&quot; install bower --save-dev --config.interactive=false" WorkingDirectory="$(SolutionDir)" />
 		<Message Text="Bower installed!"/>
 	</Target>
 	<Target Name="RestoreBowerPkgs" DependsOnTargets="InstallBower">


### PR DESCRIPTION
Bower will ask if you want to allow analytics if bower has not been run
before which will cause the build to fail.

I have added command line param to make sure installing bower is non
interactive

http://bower.io/docs/api/#running-on-a-continuous-integration-server
